### PR TITLE
FIX import:  create publication without existing index.md

### DIFF
--- a/academic/editFM.py
+++ b/academic/editFM.py
@@ -16,9 +16,12 @@ class EditableFM:
         self.path = ""
 
     def load(self, file: Path):
-        self.fm = []
         self.content = []
         self.path = self.base_path / file
+        if not self.path.exists():
+            self.fm = {}
+            return
+        self.fm = []
 
         file = open(self.path, "r").readlines()
 


### PR DESCRIPTION
When running `% academic import --bibtex ~/pubs.bib` for the first time I got the error below, seemingly because the script was trying to read a non-existing `index.md` file. With this fix I could run the import successfully. I still get the `need to install Go` message despite having installed go (I can run `hugo server`), but it does not seem to cause any issues.

```
Error: we found a go.mod file in your project, but you need to install Go to use it. See https://golang.org/dl/.: module "github.com/wowchemy/wowchemy-hugo-modules/wowchemy" not found; either add it as a Hugo Module or store it in "/Users/christian/Code/christianbrodbeck.net/themes".: module does not exist
Traceback (most recent call last):
  File "/Users/christian/anaconda3/envs/academic/bin/academic", line 33, in <module>
    sys.exit(load_entry_point('academic', 'console_scripts', 'academic')())
  File "/Users/christian/Code/academic-admin/academic/cli.py", line 43, in main
    parse_args(sys.argv[1:])  # Strip command name, leave just args.
  File "/Users/christian/Code/academic-admin/academic/cli.py", line 101, in parse_args
    import_bibtex(
  File "/Users/christian/Code/academic-admin/academic/import_bibtex.py", line 55, in import_bibtex
    parse_bibtex_entry(
  File "/Users/christian/Code/academic-admin/academic/import_bibtex.py", line 100, in parse_bibtex_entry
    page.load("index.md")
  File "/Users/christian/Code/academic-admin/academic/editFM.py", line 23, in load
    file = open(self.path, "r").readlines()
FileNotFoundError: [Errno 2] No such file or directory: 'content/publication/gramfort-mne-2014/index.md'
``` 