### PR TITLE
Add --publish-date-from-bibtex flag

### DIFF
--- a/academic/cli.py
+++ b/academic/cli.py
@@ -53,6 +53,9 @@ def parse_args(args):
     parser_a.add_argument(
         "--normalize", action="store_true", help="Normalize each keyword to lowercase with uppercase first letter",
     )
+    parser_a.add_argument(
+        "--publish-date-from-bibtex", action="store_true", help="Use the bibtex date field as the publishDate metadata instead of the current time"
+    )
     parser_a.add_argument("-v", "--verbose", action="store_true", required=False, help="Verbose mode")
     parser_a.add_argument(
         "-dr", "--dry-run", action="store_true", required=False, help="Perform a dry run (Bibtex only)",
@@ -88,6 +91,7 @@ def parse_args(args):
                 overwrite=known_args.overwrite,
                 normalize=known_args.normalize,
                 dry_run=known_args.dry_run,
+                publish_date_from_bibtex=known_args.publish_date_from_bibtex,
             )
 
 

--- a/academic/import_bibtex.py
+++ b/academic/import_bibtex.py
@@ -17,9 +17,7 @@ from academic.editFM import EditableFM
 from academic.publication_type import PUB_TYPES, PublicationType
 
 
-def import_bibtex(
-    bibtex, pub_dir="publication", featured=False, overwrite=False, normalize=False, dry_run=False,
-):
+def import_bibtex(bibtex, pub_dir="publication", featured=False, overwrite=False, normalize=False, dry_run=False, publish_date_from_bibtex=False):
     """Import publications from BibTeX file"""
     from academic.cli import AcademicError, log
 
@@ -37,13 +35,17 @@ def import_bibtex(
         bib_database = bibtexparser.load(bibtex_file, parser=parser)
         for entry in bib_database.entries:
             parse_bibtex_entry(
-                entry, pub_dir=pub_dir, featured=featured, overwrite=overwrite, normalize=normalize, dry_run=dry_run,
+                entry,
+                pub_dir=pub_dir,
+                featured=featured,
+                overwrite=overwrite,
+                normalize=normalize,
+                dry_run=dry_run,
+                publish_date_from_bibtex=publish_date_from_bibtex,
             )
 
 
-def parse_bibtex_entry(
-    entry, pub_dir="publication", featured=False, overwrite=False, normalize=False, dry_run=False,
-):
+def parse_bibtex_entry(entry, pub_dir="publication", featured=False, overwrite=False, normalize=False, dry_run=False, publish_date_from_bibtex=False):
     """Parse a bibtex entry and generate corresponding publication bundle"""
     from academic.cli import log
 
@@ -103,7 +105,12 @@ def parse_bibtex_entry(
         log.error(f'Invalid date for entry `{entry["ID"]}`.')
 
     page.fm["date"] = "-".join([year, month, day])
-    page.fm["publishDate"] = timestamp
+    if "publishDate" in page.fm:
+        pass  # don't overwrite the existing publishDate
+    elif publish_date_from_bibtex:
+        page.fm["publishDate"] = page.fm["date"]
+    else:
+        page.fm["publishDate"] = timestamp
 
     authors = None
     if "author" in entry:


### PR DESCRIPTION
When set, the publishDate field uses the bibtex value instead of the
current time. This is useful to avoid all .md files changing whenever
the bibtex file is imported.

Additionally, the bibtex importer now checks whether publishDate is already
set in the metadata and does not replace it in that case.