### PR TITLE
Improved escaping of bibtex strings

### DIFF
--- a/academic/editFM.py
+++ b/academic/editFM.py
@@ -40,13 +40,16 @@ class EditableFM:
         # Parse YAML, trying to preserve comments and whitespace
         self.fm = yaml.load("".join(self.fm))
 
+    def write_to_file(self, f):
+        f.write("{}\n".format(self.delim))
+        yaml.dump(self.fm, f)
+        f.write("{}\n".format(self.delim))
+        f.writelines(self.content)
+
     def dump(self):
         assert self.path, "You need to `.load()` first."
         if self.dry_run:
             return
 
         with open(self.path, "w", encoding="utf-8") as f:
-            f.write("{}\n".format(self.delim))
-            yaml.dump(self.fm, f)
-            f.write("{}\n".format(self.delim))
-            f.writelines(self.content)
+            self.write_to_file(f)

--- a/academic/import_bibtex.py
+++ b/academic/import_bibtex.py
@@ -84,7 +84,7 @@ def parse_bibtex_entry(
     page = EditableFM(Path(bundle_path), dry_run=dry_run)
     page.load(Path("index.md"))
 
-    page.fm["title"] = clean_bibtex_str(entry["title"])
+    page.fm["title"] = entry["title"]
 
     year, month, day = "", "01", "01"
     if "date" in entry:
@@ -119,7 +119,7 @@ def parse_bibtex_entry(
     page.fm["publication_types"] = [str(pubtype.value)]
 
     if "abstract" in entry:
-        page.fm["abstract"] = clean_bibtex_str(entry["abstract"])
+        page.fm["abstract"] = entry["abstract"]
     else:
         page.fm["abstract"] = ""
 
@@ -127,11 +127,11 @@ def parse_bibtex_entry(
 
     # Publication name.
     if "booktitle" in entry:
-        publication = "*" + clean_bibtex_str(entry["booktitle"]) + "*"
+        publication = "*" + entry["booktitle"] + "*"
     elif "journal" in entry:
-        publication = "*" + clean_bibtex_str(entry["journal"]) + "*"
+        publication = "*" + entry["journal"] + "*"
     elif "publisher" in entry:
-        publication = "*" + clean_bibtex_str(entry["publisher"]) + "*"
+        publication = "*" + entry["publisher"] + "*"
     else:
         publication = ""
     page.fm["publication"] = publication
@@ -140,10 +140,10 @@ def parse_bibtex_entry(
         page.fm["tags"] = clean_bibtex_tags(entry["keywords"], normalize)
 
     if "url" in entry:
-        page.fm["url_pdf"] = clean_bibtex_str(entry["url"])
+        page.fm["url_pdf"] = entry["url"]
 
     if "doi" in entry:
-        page.fm["doi"] = clean_bibtex_str(entry["doi"])
+        page.fm["doi"] = entry["doi"]
 
     # Save Markdown file.
     try:
@@ -202,24 +202,11 @@ def clean_bibtex_authors(author_str):
     return authors
 
 
-def clean_bibtex_str(s):
-    """Clean BibTeX string and escape TOML special characters"""
-    s = s.replace("\\", "")
-    s = s.replace('"', '\\"')
-    s = s.replace("{", "").replace("}", "")
-    s = s.replace("\t", " ").replace("\n", " ").replace("\r", "")
-    return s
-
-
 def clean_bibtex_tags(s, normalize=False):
     """Clean BibTeX keywords and convert to TOML tags"""
-
-    tags = clean_bibtex_str(s).split(",")
-    tags = [f'"{tag.strip()}"' for tag in tags]
-
+    tags = [tag.strip() for tag in s.split(",")]
     if normalize:
         tags = [tag.lower().capitalize() for tag in tags]
-
     return tags
 
 

--- a/tests/data/book.bib
+++ b/tests/data/book.bib
@@ -7,4 +7,5 @@
 Paragraph two.
 
 Paragraph three.},
+  keywords = {tag1, tag with spaces,MiXEDcASE},
 }

--- a/tests/data/book.bib
+++ b/tests/data/book.bib
@@ -1,6 +1,6 @@
 @book{book,
   author  = {Nelson Bigetti},
-  title   = {The {{Title}} of {{the book}}},
+  title   = {The {{Title}} of {{the book}} "contains 'quotes'"},
   year    = 2019,
   publisher = {{{IEEE}}},
   abstract = {Paragraph one.

--- a/tests/data/book.bib
+++ b/tests/data/book.bib
@@ -1,7 +1,8 @@
 @book{book,
   author  = {Nelson Bigetti},
-  title   = {The title of the book},
+  title   = {The {{Title}} of {{the book}}},
   year    = 2019,
+  publisher = {{{IEEE}}},
   abstract = {Paragraph one.
 
 Paragraph two.

--- a/tests/test_bibtex_import.py
+++ b/tests/test_bibtex_import.py
@@ -1,4 +1,5 @@
 import typing
+from io import StringIO
 from pathlib import Path
 
 import bibtexparser
@@ -14,11 +15,12 @@ def test_bibtex_import():
     cli.parse_args(["import", "--dry-run", "--bibtex", "tests/data/article.bib"])
 
 
-def _process_bibtex(file, expected_count=1) -> "typing.List[EditableFM]":
+def _process_bibtex(file, expected_count=1, normalize=False) -> "typing.List[EditableFM]":
     """
     Parse a BibTeX .bib file and return the parsed metadata
     :param file: The .bib file to parse
     :param expected_count: The expected number of entries inside the .bib
+    :param normalize: Whether to normalize the case of tags
     :return: The parsed metadata as a list of EditableFM
     """
     parser = BibTexParser(common_strings=True)
@@ -28,7 +30,7 @@ def _process_bibtex(file, expected_count=1) -> "typing.List[EditableFM]":
         bib_database = bibtexparser.load(bibtex_file, parser=parser)
         results = []
         for entry in bib_database.entries:
-            results.append(import_bibtex.parse_bibtex_entry(entry, dry_run=True))
+            results.append(import_bibtex.parse_bibtex_entry(entry, dry_run=True, normalize=normalize))
         assert len(results) == expected_count
         return results
 
@@ -51,3 +53,40 @@ def test_bibtex_types():
     for metadata in _process_bibtex("thesis.bib", expected_count=3):
         _test_publication_type(metadata, import_bibtex.PublicationType.Thesis)
     _test_publication_type(_process_bibtex("book.bib")[0], import_bibtex.PublicationType.Book)
+
+
+def test_resulting_yaml_output():
+    """
+    This test checks that the YAML generated for a .bib file looks as expected and that newlines are not filtered out.
+    """
+    result = _process_bibtex("book.bib", normalize=True)[0]
+
+    # Check that the paragraph breaks were not stripped from the YAML:
+    assert result.fm["abstract"] == "Paragraph one.\n\nParagraph two.\n\nParagraph three."
+
+    # Don't check the full string for publishDate since that is not constant.
+    del result.fm["publishDate"]
+
+    with StringIO() as output:
+        result.write_to_file(output)
+        output.seek(0)
+        lines = output.readlines()
+
+    lines = [line.strip() for line in lines]  # .strip() to remove newline at end
+    assert lines == [
+        "---",
+        "title: The title of the book",
+        "date: '2019-01-01'",
+        "authors:",
+        "- Nelson Bigetti",
+        "publication_types:",
+        "- '5'",
+        'abstract: "Paragraph one.\\n\\nParagraph two.\\n\\nParagraph three."',
+        "featured: false",
+        "publication: ''",
+        "tags:",
+        "- Tag1",
+        "- Tag with spaces",
+        "- Mixedcase",
+        "---",
+    ]

--- a/tests/test_bibtex_import.py
+++ b/tests/test_bibtex_import.py
@@ -76,7 +76,7 @@ def test_resulting_yaml_output():
     lines = [line.strip() for line in lines]  # .strip() to remove newline at end
     assert lines == [
         "---",
-        "title: The Title of the book",
+        "title: The Title of the book \"contains 'quotes'\"",
         "date: '2019-01-01'",
         "authors:",
         "- Nelson Bigetti",

--- a/tests/test_bibtex_import.py
+++ b/tests/test_bibtex_import.py
@@ -58,6 +58,7 @@ def test_bibtex_types():
 def test_resulting_yaml_output():
     """
     This test checks that the YAML generated for a .bib file looks as expected and that newlines are not filtered out.
+    Also checks that curly braces in the bibtex are removed correctly.
     """
     result = _process_bibtex("book.bib", normalize=True)[0]
 
@@ -75,7 +76,7 @@ def test_resulting_yaml_output():
     lines = [line.strip() for line in lines]  # .strip() to remove newline at end
     assert lines == [
         "---",
-        "title: The title of the book",
+        "title: The Title of the book",
         "date: '2019-01-01'",
         "authors:",
         "- Nelson Bigetti",
@@ -83,7 +84,7 @@ def test_resulting_yaml_output():
         "- '5'",
         'abstract: "Paragraph one.\\n\\nParagraph two.\\n\\nParagraph three."',
         "featured: false",
-        "publication: ''",
+        "publication: '*IEEE*'",
         "tags:",
         "- Tag1",
         "- Tag with spaces",


### PR DESCRIPTION
Now that the YAML is no longer written by hand but uses rueyaml we can
let the library deal with escaping and pass through the raw strings.
This also adds a test that an abstract with multiple paragraph now
contains '\n' in the raw YAML string.