### PR TITLE
fix: default path for --publication-dir to match docs

### DIFF
--- a/academic/cli.py
+++ b/academic/cli.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import subprocess
 import sys
+import os
 from argparse import RawTextHelpFormatter
 
 from academic import __version__ as version
@@ -45,7 +46,7 @@ def parse_args(args):
         "--publication-dir",
         required=False,
         type=str,
-        default="content/publication",
+        default=os.path.join("content", "publication"),
         help="Path to import publications to (default `content/publication`)",
     )
     parser_a.add_argument("--featured", action="store_true", help="Flag publications as featured")

--- a/academic/cli.py
+++ b/academic/cli.py
@@ -42,7 +42,11 @@ def parse_args(args):
     )
     parser_a.add_argument("--bibtex", required=False, type=str, help="File path to your BibTeX file")
     parser_a.add_argument(
-        "--publication-dir", required=False, type=str, default="publication", help="Path to import publications to (default `content/publication`)",
+        "--publication-dir",
+        required=False,
+        type=str,
+        default="content/publication",
+        help="Path to import publications to (default `content/publication`)",
     )
     parser_a.add_argument("--featured", action="store_true", help="Flag publications as featured")
     parser_a.add_argument("--overwrite", action="store_true", help="Overwrite existing publications")


### PR DESCRIPTION
The default for `--publication-dir` in `academic/cli.py` should be `content/publication` instead of `publication`. Otherwise, the publication bundle will be created in `publication/EntryID` instead of `content/publication/EntryID`. 
