### PR TITLE
feat: add 'note' and 'annote' fields

### DIFF
--- a/academic/import_bibtex.py
+++ b/academic/import_bibtex.py
@@ -160,6 +160,12 @@ def parse_bibtex_entry(
     if links:
         page.fm["links"] = links
 
+    if "note" in entry:
+        page.fm["note"] = clean_bibtex_str(entry["note"])
+
+    if "annote" in entry:
+        page.fm["annote"] = clean_bibtex_str(entry["annote"])
+
     # Save Markdown file.
     try:
         log.info(f"Saving Markdown to '{markdown_path}'")


### PR DESCRIPTION
The [`note`](https://www.bibtex.com/f/note-field/) and the [`annote`](https://www.bibtex.com/f/annote-field/) fields are common in bib entries. This PR add support for using them: they will be created in the page's front matter.